### PR TITLE
fix(sync): Improve Greenhouse kubeconfig loading and error reporting in `sync` command

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"os"
 	"sort"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/cloudoperators/greenhouse/api/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,15 +61,27 @@ var syncCmd = &cobra.Command{
 }
 
 func runSync(cmd *cobra.Command, args []string) error {
-	centralConfig, err := clientcmd.BuildConfigFromFlags("", greenhouseClusterKubeconfig)
-	if err != nil {
-		return fmt.Errorf("failed to build greenhouse kubeconfig: %w", err)
+	if greenhouseClusterKubeconfig == "" {
+		return fmt.Errorf("greenhouse cluster kubeconfig path is empty")
 	}
 
+	if _, err := os.Stat(greenhouseClusterKubeconfig); err != nil {
+		return fmt.Errorf("greenhouse cluster kubeconfig file not found at %q: %w", greenhouseClusterKubeconfig, err)
+	}
+
+	var (
+		centralConfig *rest.Config
+		err           error
+	)
 	if greenhouseClusterContext != "" {
 		centralConfig, err = configWithContext(greenhouseClusterContext, greenhouseClusterKubeconfig)
 		if err != nil {
-			return fmt.Errorf("failed to build greenhouse kubeconfig with context %s: %w", greenhouseClusterContext, err)
+			return fmt.Errorf("failed to build greenhouse kubeconfig with context %q from %q: %w", greenhouseClusterContext, greenhouseClusterKubeconfig, err)
+		}
+	} else {
+		centralConfig, err = clientcmd.BuildConfigFromFlags("", greenhouseClusterKubeconfig)
+		if err != nil {
+			return fmt.Errorf("failed to build greenhouse kubeconfig from %q: %w", greenhouseClusterKubeconfig, err)
 		}
 	}
 


### PR DESCRIPTION

### Description
This PR improves the robustness and clarity of the `sync` command when loading the Greenhouse cluster kubeconfig. It addresses a common issue where `client-go` would report a cryptic "invalid configuration: no configuration has been provided" error when the default context in a kubeconfig file was missing or invalid, even if a specific context was provided via flags.

### Key Changes
- **Context-First Loading**: If `--greenhouse-cluster-context` is specified, the tool now attempts to build the REST configuration using that context directly. This bypasses the initial attempt to load the default/current context, which was previously causing premature failures.
- **Explicit File Validation**: Added an explicit check for the existence of the Greenhouse kubeconfig file using `os.Stat`. This ensures a clear "file not found" error is returned instead of the generic Kubernetes configuration error.
- **Enhanced Error Messages**: Improved error wrapping to include the specific file path and context name that failed to load, making troubleshooting significantly easier for users.

### Why this is needed
Previously, the `sync` command would call `clientcmd.BuildConfigFromFlags("", path)` which defaults to the "current-context". If the kubeconfig existed but the current-context was empty or pointed to a non-existent entry, the command would fail immediately, preventing the user-supplied `--greenhouse-cluster-context` from ever being used.

 