### PR TITLE
feat(actions): add common issue lifecycle workflows

### DIFF
--- a/.github/workflows/issue-project-sync.yml
+++ b/.github/workflows/issue-project-sync.yml
@@ -1,0 +1,13 @@
+name: Issue Project Sync
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  sync:
+    if: github.event.label.name == 'backlog'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudoperators/common/workflows/issue-project-sync@main
+        with:
+          GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}

--- a/.github/workflows/issue-project-sync.yml
+++ b/.github/workflows/issue-project-sync.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: read
+
 jobs:
   sync:
     if: github.event.label.name == 'backlog'

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,10 @@
+name: Issue Triage
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudoperators/common/workflows/issue-triage@main

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,16 @@ The following rule governs code contributions:
 
 ## Issues and Planning
 
-* We use GitHub issues to track bugs and enhancement requests.
+We follow a shared issue lifecycle across all `cloudoperators` repositories. See the **[Issue Lifecycle documentation](https://github.com/cloudoperators/common/blob/main/ISSUE_LIFECYCLE.md)** for the full process including:
 
-* Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.
+* Automatic triage labeling
+* Triage decision matrix
+* Definition of Ready
+* Refinement workflow
+* Sprint/quarter planning
+
+Quick links:
+
+* [Issues needing triage (org-wide)](https://github.com/issues?q=org%3Acloudoperators+label%3Aneeds-triage+is%3Aopen+sort%3Acreated-asc)
+* [Issues ready to pick up (`backlog`)](https://github.com/cloudoperators/cloudctl/issues?q=is%3Aopen+is%3Aissue+label%3Abacklog)
+* [Project board](https://github.com/orgs/cloudoperators/projects/9)


### PR DESCRIPTION
## Summary

Adds issue lifecycle workflows (triage + project sync) referencing the shared actions in `cloudoperators/common`.

### Changes:
- `.github/workflows/issue-triage.yml` — Auto-labels new issues with `needs-triage` + posts welcome comment
- `.github/workflows/issue-project-sync.yml` — Adds issues to project #9 when `backlog` label is applied
- `CONTRIBUTING.md` — Updated to reference shared Issue Lifecycle documentation

### Prerequisites:
- Org-level secret `GH_PROJECT_TOKEN` must be configured

⚠️ **Dependency:** Merge https://github.com/cloudoperators/common/pull/58 first — the workflows reference `cloudoperators/common/workflows/...@main`.