### PR TITLE
fix(config): add env key replacer so dash-named flags map correctly to env vars

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -82,6 +83,7 @@ func setupConfig() error {
 
 	// Optionally read environment variables, config files, etc.
 	viper.SetEnvPrefix("CLOUDCTL")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 	viper.SetConfigType("yaml")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -61,6 +61,27 @@ func TestConfigurationLoad(t *testing.T) {
 	g.Expect(viper.GetString("kubeconfig")).To(Equal("A"))
 }
 
+func TestEnvKeyReplacerDashToUnderscore(t *testing.T) {
+	g := NewWithT(t)
+
+	const envKey = "CLOUDCTL_GREENHOUSE_CLUSTER_KUBECONFIG"
+	const viperKey = "greenhouse-cluster-kubeconfig"
+	const testValue = "/tmp/test-kubeconfig"
+
+	orig := os.Getenv(envKey)
+	os.Setenv(envKey, testValue)
+
+	t.Cleanup(func() {
+		viper.Reset()
+		os.Setenv(envKey, orig)
+	})
+
+	g.Expect(setupConfig()).To(BeNil())
+
+	// The env key replacer must map CLOUDCTL_GREENHOUSE_CLUSTER_KUBECONFIG → greenhouse-cluster-kubeconfig
+	g.Expect(viper.GetString(viperKey)).To(Equal(testValue))
+}
+
 func TestMissingConfigurationFile(t *testing.T) {
 	g := NewWithT(t)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -71,6 +71,7 @@ func TestEnvKeyReplacerDashToUnderscore(t *testing.T) {
 	t.Setenv(envKey, testValue)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("CLOUDCTL_CONFIG", "")
 	t.Chdir(t.TempDir())
 	t.Cleanup(func() { viper.Reset() })
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -69,6 +69,7 @@ func TestEnvKeyReplacerDashToUnderscore(t *testing.T) {
 	const testValue = "/tmp/test-kubeconfig"
 
 	t.Setenv(envKey, testValue)
+	t.Setenv("HOME", t.TempDir())
 	t.Cleanup(func() { viper.Reset() })
 
 	g.Expect(setupConfig()).To(BeNil())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -66,7 +67,7 @@ func TestEnvKeyReplacerDashToUnderscore(t *testing.T) {
 
 	const envKey = "CLOUDCTL_GREENHOUSE_CLUSTER_KUBECONFIG"
 	const viperKey = "greenhouse-cluster-kubeconfig"
-	const testValue = "/tmp/test-kubeconfig"
+	testValue := filepath.Join(t.TempDir(), "test-kubeconfig")
 
 	t.Setenv(envKey, testValue)
 	t.Setenv("HOME", t.TempDir())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -70,6 +70,8 @@ func TestEnvKeyReplacerDashToUnderscore(t *testing.T) {
 
 	t.Setenv(envKey, testValue)
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Chdir(t.TempDir())
 	t.Cleanup(func() { viper.Reset() })
 
 	g.Expect(setupConfig()).To(BeNil())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -68,13 +68,8 @@ func TestEnvKeyReplacerDashToUnderscore(t *testing.T) {
 	const viperKey = "greenhouse-cluster-kubeconfig"
 	const testValue = "/tmp/test-kubeconfig"
 
-	orig := os.Getenv(envKey)
-	os.Setenv(envKey, testValue)
-
-	t.Cleanup(func() {
-		viper.Reset()
-		os.Setenv(envKey, orig)
-	})
+	t.Setenv(envKey, testValue)
+	t.Cleanup(func() { viper.Reset() })
 
 	g.Expect(setupConfig()).To(BeNil())
 


### PR DESCRIPTION
## Summary

- Adds `viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))` in `setupConfig()` so that flags with dashes in their names (e.g. `greenhouse-cluster-kubeconfig`) correctly map to their env var counterparts (e.g. `CLOUDCTL_GREENHOUSE_CLUSTER_KUBECONFIG`)
- Without this, Viper looked for env vars with literal dashes, which never matched, causing env vars to be silently ignored and config file values to incorrectly take priority over them

## Root cause

`viper.AutomaticEnv()` maps Viper keys to env vars using the key name as-is. Since flag names use dashes and env vars use underscores, the lookup always failed. Config file values then won over env vars, inverting the expected priority order (flags > env vars > config file > defaults).

## Test plan

- [ ] Set `CLOUDCTL_GREENHOUSE_CLUSTER_KUBECONFIG=/some/path` without passing `-k` — should now use the env var value instead of `~/.kube/config`
- [ ] Set env var and a config file with a different path — env var should take priority
- [ ] Pass `-k /explicit/path` with env var set — explicit flag still takes highest priority
- [ ] `go test ./cmd/...` passes